### PR TITLE
FIX: property model in user properties association

### DIFF
--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -2,7 +2,7 @@
 
 class Property < ApplicationRecord
   belongs_to :user
-  has_many :user_properties
+  has_many :user_properties, dependent: :destroy
   has_many :users, through: :user_properties
 
   validates :property_type, :operation_type, :address, :bedrooms, :bathrooms, :area, :urls, presence: true


### PR DESCRIPTION
Fixed error when deleting a property because of foreign key restraint by adding a dependant destroy sentence to the property model.